### PR TITLE
Pin fast-xml-parser to 4.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cache-directory": "~2.0",
         "ci": "^2.3.0",
         "decompress": "4.2.1",
-        "fast-xml-parser": "latest",
+        "fast-xml-parser": "4.5.2",
         "handlebars": "*"
       },
       "devDependencies": {


### PR DESCRIPTION
This pins the fast-xml-parser lib to version 4.5.2 rather than latest to avoid unpredictable breakages.