### PR TITLE
Set primary-site-*-url attrs when multiple sources

### DIFF
--- a/lib/partial-build-extension.js
+++ b/lib/partial-build-extension.js
@@ -46,17 +46,25 @@ module.exports.register = function ({ config = {} }) {
       return
     }
     const sourcesLength = playbook.content.sources.length
-    if (sourcesLength !== 1) {
+    if (sourcesLength === 1) {
+      Object.assign(
+        playbook.content.sources[0],
+        isBranch
+          ? {
+              branches: [refname],
+              tags: [],
+            }
+          : {
+              branches: [],
+              tags: [refname],
+            }
+      )
+      if (isAuthorMode) {
+        const authorUrl = resolveAuthorUrl(playbook.dir)
+        Object.assign(playbook.content.sources[0], { url: authorUrl })
+      }
+    } else {
       console.log(`sources.length = ${sourcesLength} so deferring filtering till contentAggregated`)
-      return
-    }
-    Object.assign(
-      playbook.content.sources[0],
-      isBranch ? { branches: [refname], tags: [] } : { branches: [], tags: [refname] }
-    )
-    if (isAuthorMode) {
-      const authorUrl = resolveAuthorUrl(playbook.dir)
-      Object.assign(playbook.content.sources[0], { url: authorUrl })
     }
     Object.assign(asciidocAttrs, { 'primary-site-url': '.', 'primary-site-manifest-url': siteManifestUrl })
     this.updateVariables({ playbook })

--- a/test/partial-build-extension-test.js
+++ b/test/partial-build-extension-test.js
@@ -449,6 +449,40 @@ describe('partial-build-extension', () => {
           'https://raw.githubusercontent.com/org/repo/6.0.0/gradle.properties',
         ])
       })
+
+      it('multiple sources defaults primary-site-url and primary-site-manifest-url', async () => {
+        playbook.dir = WORK_DIR
+        playbook.site.url = httpServerUrl
+        playbook.content.sources = [
+          {
+            url: '.',
+            branches: ['main'],
+            startPaths: ['new-start-path'],
+          },
+          {
+            url: '.',
+            branches: ['1.0.x'],
+            startPaths: ['old-start-path'],
+          },
+        ]
+        ext.register.call(generatorContext, { config: { refname: 'HEAD', version: '7.0.0-SNAPSHOT' } })
+        generatorContext.updateVariables({ playbook })
+        await generatorContext.playbookBuilt(generatorContext.variables)
+        expect(playbook.content.sources).to.eql([
+          {
+            url: '.',
+            branches: ['main'],
+            startPaths: ['new-start-path'],
+          },
+          {
+            url: '.',
+            branches: ['1.0.x'],
+            startPaths: ['old-start-path'],
+          },
+        ])
+        expect(playbook.asciidoc.attributes['primary-site-manifest-url']).to.eql(`${httpServerUrl}/site-manifest.json`)
+        expect(playbook.asciidoc.attributes['primary-site-url']).to.eql('.')
+      })
     })
   })
 })


### PR DESCRIPTION
Previously the partial-build-extension did not set the primary-site-*-url
attributes when there were multiple sources. This prevented the atlas
plugin from running when there were multiple sources.

This fix ensures that the primary-site-*-url attributes are now set.
